### PR TITLE
Update project ref to template-node-angular

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -61,19 +61,19 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "catalyst-webui-angular:build",
+            "browserTarget": "template-node-angular:build",
             "port": 3001
           },
           "configurations": {
             "production": {
-              "browserTarget": "catalyst-webui-angular:build:production"
+              "browserTarget": "template-node-angular:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "catalyst-webui-angular:build"
+            "browserTarget": "template-node-angular:build"
           }
         },
         "test": {
@@ -107,7 +107,7 @@
         }
       }
     },
-    "catalyst-webui-angular-e2e": {
+    "template-node-angular-e2e": {
       "root": "e2e/",
       "projectType": "application",
       "prefix": "",
@@ -116,11 +116,11 @@
           "builder": "@angular-devkit/build-angular:protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "catalyst-webui-angular:serve"
+            "devServerTarget": "template-node-angular:serve"
           },
           "configurations": {
             "production": {
-              "devServerTarget": "catalyst-webui-angular:serve:production"
+              "devServerTarget": "template-node-angular:serve:production"
             }
           }
         },
@@ -136,5 +136,5 @@
       }
     }
   },
-  "defaultProject": "catalyst-webui-angular"
+  "defaultProject": "template-node-angular"
 }


### PR DESCRIPTION
This makes `ng serve` work in client, which is good for TDD 
```
Colins-MacBook-Pro:client colinhobday$ ng serve
** Angular Live Development Server is listening on localhost:3001, open your browser on http://localhost:3001/ **
                                                                                          
Date: 2019-10-31T09:54:11.391Z
Hash: aba024bc5ca37a263047
Time: 43245ms
chunk {main} main.js, main.js.map (main) 30.2 kB [initial] [rendered]
chunk {polyfills} polyfills.js, polyfills.js.map (polyfills) 237 kB [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 6.08 kB [entry] [rendered]
chunk {styles} styles.js, styles.js.map (styles) 1.94 MB [initial] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 5.42 MB [initial] [rendered]
ℹ ｢wdm｣: Compiled successfully.
```


It fixes the error 
```
Colins-MacBook-Pro:client colinhobday$ ng serve
Project 'catalyst-webui-angular' could not be found in workspace.
Error: Project 'catalyst-webui-angular' could not be found in workspace.
```
